### PR TITLE
Fix BpmAudit inheritance mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,5 +67,15 @@
       <artifactId>lombok</artifactId>
       <version>1.18.38</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <version>3.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+      <version>3.3.1</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/resources/openapi/schemas/audit/bpm/bpmAudit.yaml
+++ b/src/main/resources/openapi/schemas/audit/bpm/bpmAudit.yaml
@@ -1,9 +1,9 @@
 BpmAudit:
-  type: object
   allOf:
     - $ref: '../auditKafka.yaml#/AuditKafka'
-  required:
-    - bpmType
-  properties:
-    bpmType:
-      $ref: '../../enums/bpmType.yaml#/BpmType'
+    - type: object
+      required:
+        - bpmType
+      properties:
+        bpmType:
+          $ref: '../../enums/bpmType.yaml#/BpmType'


### PR DESCRIPTION
## Summary
- ensure `BpmAudit` schema extends `AuditKafka`
- add Spring Boot starters to satisfy generated model dependencies

## Testing
- `mvn -q -e -ntp package` *(fails: Plugin org.openapitools:openapi-generator-maven-plugin:7.6.0 or one of its dependencies could not be resolved; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892120c0340832a9fa0322be926af82