### PR TITLE
Add discriminators to Kafka schemas

### DIFF
--- a/src/main/resources/openapi/schemas/audit/auditKafka.yaml
+++ b/src/main/resources/openapi/schemas/audit/auditKafka.yaml
@@ -7,3 +7,9 @@ AuditKafka:
       properties:
         auditType:
           $ref: '../enums/bpmType.yaml#/BpmType'
+  discriminator:
+    propertyName: messageModelType
+    mapping:
+      IPE_AUDIT: './bpm/ipeAudit.yaml#/IpeAudit'
+      CAMUNDA_AUDIT: './bpm/camundaAudit.yaml#/CamundaAudit'
+      APPLICATION_AUDIT: './application/applicationAudit.yaml#/ApplicationAudit'

--- a/src/main/resources/openapi/schemas/dlq/genericDlq.yaml
+++ b/src/main/resources/openapi/schemas/dlq/genericDlq.yaml
@@ -22,3 +22,8 @@ GenericDlq:
           $ref: '../enums/errorType.yaml#/ErrorType'
         errorMsg:
           type: string
+  discriminator:
+    propertyName: messageModelType
+    mapping:
+      TASK_DLQ: './taskDlq.yaml#/TaskDlq'
+      INSTANCE_DLQ: './instanceDlq.yaml#/InstanceDlq'

--- a/src/main/resources/openapi/schemas/genericKafka.yaml
+++ b/src/main/resources/openapi/schemas/genericKafka.yaml
@@ -28,3 +28,11 @@ GenericKafka:
       type: string
     partitionKey:
       type: string
+  discriminator:
+    propertyName: messageModelType
+    mapping:
+      TASK_DLQ: './dlq/taskDlq.yaml#/TaskDlq'
+      INSTANCE_DLQ: './dlq/instanceDlq.yaml#/InstanceDlq'
+      IPE_AUDIT: './audit/bpm/ipeAudit.yaml#/IpeAudit'
+      CAMUNDA_AUDIT: './audit/bpm/camundaAudit.yaml#/CamundaAudit'
+      APPLICATION_AUDIT: './audit/application/applicationAudit.yaml#/ApplicationAudit'


### PR DESCRIPTION
## Summary
- specify discriminators in GenericKafka, GenericDlq and AuditKafka schemas to support inheritance when generating models

## Testing
- `MAVEN_OPTS="-Djava.net.preferIPv4Stack=true" mvn -e clean package` *(fails: Plugin org.openapitools:openapi-generator-maven-plugin:7.6.0 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892191e0f88832ab010f4da592be6d8