### PR TITLE
Use consistent message model type names

### DIFF
--- a/src/main/resources/openapi/schemas/audit/auditKafka.yaml
+++ b/src/main/resources/openapi/schemas/audit/auditKafka.yaml
@@ -10,6 +10,6 @@ AuditKafka:
   discriminator:
     propertyName: messageModelType
     mapping:
-      IPE_AUDIT: './bpm/ipeAudit.yaml#/IpeAudit'
-      CAMUNDA_AUDIT: './bpm/camundaAudit.yaml#/CamundaAudit'
-      APPLICATION_AUDIT: './application/applicationAudit.yaml#/ApplicationAudit'
+      IpeAudit: './bpm/ipeAudit.yaml#/IpeAudit'
+      CamundaAudit: './bpm/camundaAudit.yaml#/CamundaAudit'
+      ApplicationAudit: './application/applicationAudit.yaml#/ApplicationAudit'

--- a/src/main/resources/openapi/schemas/dlq/genericDlq.yaml
+++ b/src/main/resources/openapi/schemas/dlq/genericDlq.yaml
@@ -25,5 +25,5 @@ GenericDlq:
   discriminator:
     propertyName: messageModelType
     mapping:
-      TASK_DLQ: './taskDlq.yaml#/TaskDlq'
-      INSTANCE_DLQ: './instanceDlq.yaml#/InstanceDlq'
+      TaskDlq: './taskDlq.yaml#/TaskDlq'
+      InstanceDlq: './instanceDlq.yaml#/InstanceDlq'

--- a/src/main/resources/openapi/schemas/enums/messageModelType.yaml
+++ b/src/main/resources/openapi/schemas/enums/messageModelType.yaml
@@ -1,8 +1,8 @@
 MessageModelType:
   type: string
   enum:
-    - TASK_DLQ
-    - INSTANCE_DLQ
-    - IPE_AUDIT
-    - CAMUNDA_AUDIT
-    - APPLICATION_AUDIT
+    - TaskDlq
+    - InstanceDlq
+    - IpeAudit
+    - CamundaAudit
+    - ApplicationAudit

--- a/src/main/resources/openapi/schemas/genericKafka.yaml
+++ b/src/main/resources/openapi/schemas/genericKafka.yaml
@@ -31,8 +31,8 @@ GenericKafka:
   discriminator:
     propertyName: messageModelType
     mapping:
-      TASK_DLQ: './dlq/taskDlq.yaml#/TaskDlq'
-      INSTANCE_DLQ: './dlq/instanceDlq.yaml#/InstanceDlq'
-      IPE_AUDIT: './audit/bpm/ipeAudit.yaml#/IpeAudit'
-      CAMUNDA_AUDIT: './audit/bpm/camundaAudit.yaml#/CamundaAudit'
-      APPLICATION_AUDIT: './audit/application/applicationAudit.yaml#/ApplicationAudit'
+      TaskDlq: './dlq/taskDlq.yaml#/TaskDlq'
+      InstanceDlq: './dlq/instanceDlq.yaml#/InstanceDlq'
+      IpeAudit: './audit/bpm/ipeAudit.yaml#/IpeAudit'
+      CamundaAudit: './audit/bpm/camundaAudit.yaml#/CamundaAudit'
+      ApplicationAudit: './audit/application/applicationAudit.yaml#/ApplicationAudit'

--- a/src/main/resources/openapi/schemas/kafkaEnvelope.yaml
+++ b/src/main/resources/openapi/schemas/kafkaEnvelope.yaml
@@ -8,8 +8,8 @@ KafkaEnvelope:
   discriminator:
     propertyName: messageModelType
     mapping:
-      TASK_DLQ: './dlq/taskDlq.yaml#/TaskDlq'
-      INSTANCE_DLQ: './dlq/instanceDlq.yaml#/InstanceDlq'
-      IPE_AUDIT: './audit/bpm/ipeAudit.yaml#/IpeAudit'
-      CAMUNDA_AUDIT: './audit/bpm/camundaAudit.yaml#/CamundaAudit'
-      APPLICATION_AUDIT: './audit/application/applicationAudit.yaml#/ApplicationAudit'
+      TaskDlq: './dlq/taskDlq.yaml#/TaskDlq'
+      InstanceDlq: './dlq/instanceDlq.yaml#/InstanceDlq'
+      IpeAudit: './audit/bpm/ipeAudit.yaml#/IpeAudit'
+      CamundaAudit: './audit/bpm/camundaAudit.yaml#/CamundaAudit'
+      ApplicationAudit: './audit/application/applicationAudit.yaml#/ApplicationAudit'


### PR DESCRIPTION
## Summary
- ensure message model type names use a consistent casing
- align discriminator mappings with new values

## Testing
- `mvn -q package` *(fails: Could not transfer openapi-generator-maven-plugin)*
- `java -jar openapi-generator-cli.jar generate -g spring -i src/main/resources/openapi/comboKafka.yaml -o target/generated-sources/openapi --model-package com.myproject.library.kafka.model --additional-properties=useJakartaEe=true,modelNameSuffix=MessageModel,modelInheritance=true,useLombokAnnotations=true,useOneOfDiscriminatorLookup=true --generate-alias-as-model`


------
https://chatgpt.com/codex/tasks/task_e_68921d1c9464832ab5b5c350fe3bb125