### PR TITLE
Fix discriminator mapping references in audit and DLQ specs

### DIFF
--- a/src/main/resources/openapi/schemas/audit/auditKafka.yaml
+++ b/src/main/resources/openapi/schemas/audit/auditKafka.yaml
@@ -10,6 +10,6 @@ AuditKafka:
   discriminator:
     propertyName: messageModelType
     mapping:
-      IpeAudit: './bpm/ipeAudit.yaml#/IpeAudit'
-      CamundaAudit: './bpm/camundaAudit.yaml#/CamundaAudit'
-      ApplicationAudit: './application/applicationAudit.yaml#/ApplicationAudit'
+      IpeAudit: '#/components/schemas/IpeAudit'
+      CamundaAudit: '#/components/schemas/CamundaAudit'
+      ApplicationAudit: '#/components/schemas/ApplicationAudit'

--- a/src/main/resources/openapi/schemas/dlq/genericDlq.yaml
+++ b/src/main/resources/openapi/schemas/dlq/genericDlq.yaml
@@ -25,5 +25,5 @@ GenericDlq:
   discriminator:
     propertyName: messageModelType
     mapping:
-      TaskDlq: './taskDlq.yaml#/TaskDlq'
-      InstanceDlq: './instanceDlq.yaml#/InstanceDlq'
+      TaskDlq: '#/components/schemas/TaskDlq'
+      InstanceDlq: '#/components/schemas/InstanceDlq'


### PR DESCRIPTION
## Summary
- reference top-level component schemas in discriminator mappings to avoid ERRORUNKNOWN types in generated models

## Testing
- `mvn -q -e clean generate-sources` *(fails: Plugin org.openapitools:openapi-generator-maven-plugin:7.6.0... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689222a44ac8832aaceb0fc35f9bd9dd